### PR TITLE
Basic認証を導入

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,15 @@
 class ApplicationController < ActionController::Base
   # 未ログインの場合ログイン画面に遷移
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :basic_auth
 
   protected
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    end
+  end
 
   def configure_permitted_parameters
     # deviseのUserモデルに関わるリクエストからパラメーターを取得して保存する


### PR DESCRIPTION
#What
Basic認証を導入しました
#why
Basic認証導入によって未許可ユーザーのログインを防ぐため